### PR TITLE
Different AreaStyle for each Y-value for StairstepPlot, CategoryAxisModel's firstCategoryIsZero.

### DIFF
--- a/src/commonMain/kotlin/io/github/koalaplot/core/line/LinePlot.kt
+++ b/src/commonMain/kotlin/io/github/koalaplot/core/line/LinePlot.kt
@@ -517,18 +517,10 @@ private fun DrawScope.fillRectangle(
     rightBottom: Offset,
     areaStyle: AreaStyle
 ) {
-    val rectangle = Path().apply {
-        fillType = PathFillType.EvenOdd
-        moveTo(leftTop)
-        lineTo(rightBottom.x, leftTop.y)
-        lineTo(rightBottom)
-        lineTo(leftTop.x, rightBottom.y)
-        lineTo(leftTop)
-        close()
-    }
-    drawPath(
-        rectangle,
+    drawRect(
         brush = areaStyle.brush,
+        topLeft = leftTop,
+        size = (rightBottom - leftTop).run { Size(x, y) },
         alpha = areaStyle.alpha,
         style = Fill,
         colorFilter = areaStyle.colorFilter,

--- a/src/commonMain/kotlin/io/github/koalaplot/core/xygraph/CategoryAxisModel.kt
+++ b/src/commonMain/kotlin/io/github/koalaplot/core/xygraph/CategoryAxisModel.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.unit.dp
  */
 public class CategoryAxisModel<T>(
     private val categories: List<T>,
+    private val firstCategoryIsZero: Boolean = false,
     override val minimumMajorTickSpacing: Dp = 50.dp,
 ) : AxisModel<T> {
     /**
@@ -24,7 +25,11 @@ public class CategoryAxisModel<T>(
     override fun computeOffset(point: T): Float {
         val index = categories.indexOf(point)
         require(index != -1) { "The provided category '$point' is not a valid value for this axis." }
-        return ((index + 1).toFloat() / (categories.size + 1).toFloat())
+        return if (firstCategoryIsZero) {
+            index.toFloat() / categories.size
+        } else {
+            ((index + 1).toFloat() / (categories.size + 1).toFloat())
+        }
     }
 
     override fun computeTickValues(axisLength: Dp): io.github.koalaplot.core.xygraph.TickValues<T> {


### PR DESCRIPTION
I've customized `StairstepPlot` further to allow different `AreaStyle` for each Y-value, along with customizable `lineStyle` for each Y-value "cap", as shown below:
![Styled StairstepPlot](https://github.com/KoalaPlot/koalaplot-core/assets/3026524/1d01b03c-c625-461c-8700-206b6ccb64dc)
_(The "cap" and the area can have the same color, or all the areas can have the same color, if one wishes)._

In order for the area to fill to the X-axis (y = 0), I have to modify `CategoryAxisModel` to place first _category_ at the zero position, if the `firstCategoryIsZero` parameter is set to `true`.