### PR TITLE
feat(PieChart): add pieStartAngle parameter to configure the starting angle of the pie chart

### DIFF
--- a/src/commonMain/kotlin/io/github/koalaplot/core/pie/CircularLabelPositionProvider.kt
+++ b/src/commonMain/kotlin/io/github/koalaplot/core/pie/CircularLabelPositionProvider.kt
@@ -323,7 +323,7 @@ public class CircularLabelPositionProvider(
  * clockwise.
  */
 @Suppress("MagicNumber")
-private enum class Quadrant(val angleRange: ClosedFloatingPointRange<Float>) {
+internal enum class Quadrant(val angleRange: ClosedFloatingPointRange<Float>) {
     NorthEast(-90f..0f),
     SouthEast(0f..90f),
     SouthWest(90f..180f),

--- a/src/commonMain/kotlin/io/github/koalaplot/core/pie/CircularLabelPositionProvider.kt
+++ b/src/commonMain/kotlin/io/github/koalaplot/core/pie/CircularLabelPositionProvider.kt
@@ -89,13 +89,16 @@ public class CircularLabelPositionProvider(
         labelPlaceables.forEachIndexed { index, placeable ->
             val centerAngle = pieSliceDatas[index].startAngle + (pieSliceDatas[index].angle / 2f)
 
-            val matchingQuadrant = Quadrant.entries.first {
+            val matchingQuadrant = Quadrant.entries.find {
                 it.angleRange.contains(centerAngle.toDegrees().value)
             }
-            sliceGroups[matchingQuadrant] =
-                (sliceGroups.getOrElse(matchingQuadrant) { ArrayList() }).apply {
-                    add(SliceLabelData(index, pieSliceDatas[index], placeable, centerAngle))
-                }
+
+            if (matchingQuadrant != null) {
+                sliceGroups[matchingQuadrant] =
+                    (sliceGroups.getOrElse(matchingQuadrant) { ArrayList() }).apply {
+                        add(SliceLabelData(index, pieSliceDatas[index], placeable, centerAngle))
+                    }
+            }
         }
 
         return sliceGroups

--- a/src/commonMain/kotlin/io/github/koalaplot/core/pie/PieChart.kt
+++ b/src/commonMain/kotlin/io/github/koalaplot/core/pie/PieChart.kt
@@ -83,7 +83,8 @@ private const val AngleCCWTop = -90f
 
 private fun makePieSliceData(
     data: List<Float>,
-    beta: Float
+    beta: Float,
+    pieStartAngle: AngularValue,
 ): List<PieSliceData> {
     val total = data.sumOf {
         it.toDouble()
@@ -96,7 +97,7 @@ private fun makePieSliceData(
     }
 
     return buildList {
-        var startAngle = AngleCCWTop
+        var startAngle = pieStartAngle.toDegrees().value
         for (i in data.indices) {
             val extent = data[i] / total * DegreesFullCircle * beta
             add(PieSliceData(startAngle.deg, extent.deg))
@@ -188,6 +189,7 @@ private const val LabelFadeInDuration = 1000
  * @param forceCenteredPie If true, will force the pie to be centered within its parent, by adjusting (decreasing) the
  * pie size to accommodate label sizes and positions. If false, will maximize the pie diameter.
  * @param animationSpec Specifies the animation to use when the pie chart is first drawn.
+ * @param pieStartAngle Sets an angle for the pie data to start at. Defaults to the top of the pie.
  */
 @ExperimentalKoalaPlotApi
 @Composable
@@ -206,7 +208,8 @@ public fun PieChart(
     minPieDiameter: Dp = 100.dp,
     maxPieDiameter: Dp = 300.dp,
     forceCenteredPie: Boolean = false,
-    animationSpec: AnimationSpec<Float> = KoalaPlotTheme.animationSpec
+    animationSpec: AnimationSpec<Float> = KoalaPlotTheme.animationSpec,
+    pieStartAngle: AngularValue = AngleCCWTop.deg,
 ) {
     require(holeSize in 0f..1f) { "holeSize must be between 0 and 1" }
     require(maxPieDiameter != Dp.Unspecified) { "maxPieDiameter cannot be Unspecified" }
@@ -221,10 +224,10 @@ public fun PieChart(
     }
 
     // pieSliceData that gets animated - used for drawing the pie
-    val pieSliceData = remember(values, beta.value) { makePieSliceData(values, beta.value) }
+    val pieSliceData = remember(values, beta.value) { makePieSliceData(values, beta.value, pieStartAngle) }
 
     // pieSliceData when the animation is complete - used for sizing & label layout/positioning
-    val finalPieSliceData = remember(values) { makePieSliceData(values, 1f) }
+    val finalPieSliceData = remember(values) { makePieSliceData(values, 1f, pieStartAngle) }
 
     val pieMeasurePolicy =
         remember(finalPieSliceData, holeSize, labelPositionProvider, minPieDiameter, forceCenteredPie) {

--- a/src/jvmTest/kotlin/io/github/koalaplot/core/pie/CircularLabelPositionProviderTest.kt
+++ b/src/jvmTest/kotlin/io/github/koalaplot/core/pie/CircularLabelPositionProviderTest.kt
@@ -1,0 +1,66 @@
+package io.github.koalaplot.core.pie
+
+import io.github.koalaplot.core.util.Degrees
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+private const val NE_MID_ANGLE = -45.0
+private const val SE_MID_ANGLE = 45.0
+private const val SW_MID_ANGLE = 135.0
+private const val NW_MID_ANGLE = 225.0
+
+class CircularLabelPositionProviderTest {
+    //region Quadrant utility
+    @Test
+    fun `Quadrant#from returns the correct Quadrant for angles within standard boundaries`() {
+        assertEquals(Quadrant.NorthEast, Quadrant.from(Degrees(NE_MID_ANGLE)))
+        assertEquals(Quadrant.SouthEast, Quadrant.from(Degrees(SE_MID_ANGLE)))
+        assertEquals(Quadrant.SouthWest, Quadrant.from(Degrees(SW_MID_ANGLE)))
+        assertEquals(Quadrant.NorthWest, Quadrant.from(Degrees(NW_MID_ANGLE)))
+    }
+
+    /**
+     * This test in particular is important, as Quadrants are defined with inclusive ranges, leading to an overlap at
+     * the boundaries. Normalization of angles therefore can lead to slightly unexpected results.
+     */
+    @Test
+    fun `Quadrant#from returns the correct Quadrant for angles at the Quadrant boundaries`() {
+        // -90 will normalize to 270
+        assertEquals(Quadrant.NorthWest, Quadrant.from(Degrees(-90.0)))
+
+        // returns NE as it is the first quadrant covering 0 deg
+        assertEquals(Quadrant.NorthEast, Quadrant.from(Degrees(0.0)))
+
+        assertEquals(Quadrant.SouthEast, Quadrant.from(Degrees(0.001)))
+        // returns SE as it is the first quadrant covering 90 deg
+        assertEquals(Quadrant.SouthEast, Quadrant.from(Degrees(90.0)))
+
+        assertEquals(Quadrant.SouthWest, Quadrant.from(Degrees(90.001)))
+        // returns SW as it is the first quadrant covering 180 deg
+        assertEquals(Quadrant.SouthWest, Quadrant.from(Degrees(180.0)))
+
+        assertEquals(Quadrant.NorthWest, Quadrant.from(Degrees(180.001)))
+        assertEquals(Quadrant.NorthWest, Quadrant.from(Degrees(270.0)))
+    }
+
+    @Test
+    fun `Quadrant#from normalizes and returns the correct Quadrant for angles greater than 270 degrees`() {
+        assertEquals(Quadrant.NorthEast, Quadrant.from(Degrees(275.0)))
+
+        assertEquals(Quadrant.NorthEast, Quadrant.from(Degrees(1 * 360f + NE_MID_ANGLE)))
+        assertEquals(Quadrant.SouthEast, Quadrant.from(Degrees(2 * 360f + SE_MID_ANGLE)))
+        assertEquals(Quadrant.SouthWest, Quadrant.from(Degrees(3 * 360f + SW_MID_ANGLE)))
+        assertEquals(Quadrant.NorthWest, Quadrant.from(Degrees(4 * 360f + NW_MID_ANGLE)))
+    }
+
+    @Test
+    fun `Quadrant#from normalizes and returns the correct Quadrant for angles less than -90 degrees`() {
+        assertEquals(Quadrant.NorthWest, Quadrant.from(Degrees(-95.0)))
+
+        assertEquals(Quadrant.NorthEast, Quadrant.from(Degrees(1 * -360f + NE_MID_ANGLE)))
+        assertEquals(Quadrant.SouthEast, Quadrant.from(Degrees(2 * -360f + SE_MID_ANGLE)))
+        assertEquals(Quadrant.SouthWest, Quadrant.from(Degrees(3 * -360f + SW_MID_ANGLE)))
+        assertEquals(Quadrant.NorthWest, Quadrant.from(Degrees(4 * -360f + NW_MID_ANGLE)))
+    }
+    //endregion
+}

--- a/src/jvmTest/kotlin/io/github/koalaplot/core/pie/CircularLabelPositionProviderTest.kt
+++ b/src/jvmTest/kotlin/io/github/koalaplot/core/pie/CircularLabelPositionProviderTest.kt
@@ -4,19 +4,19 @@ import io.github.koalaplot.core.util.Degrees
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-private const val NE_MID_ANGLE = -45.0
-private const val SE_MID_ANGLE = 45.0
-private const val SW_MID_ANGLE = 135.0
-private const val NW_MID_ANGLE = 225.0
+private const val NeMidAngle = -45.0
+private const val SeMidAngle = 45.0
+private const val SwMidAngle = 135.0
+private const val NwMidAngle = 225.0
 
 class CircularLabelPositionProviderTest {
     //region Quadrant utility
     @Test
     fun `Quadrant#from returns the correct Quadrant for angles within standard boundaries`() {
-        assertEquals(Quadrant.NorthEast, Quadrant.from(Degrees(NE_MID_ANGLE)))
-        assertEquals(Quadrant.SouthEast, Quadrant.from(Degrees(SE_MID_ANGLE)))
-        assertEquals(Quadrant.SouthWest, Quadrant.from(Degrees(SW_MID_ANGLE)))
-        assertEquals(Quadrant.NorthWest, Quadrant.from(Degrees(NW_MID_ANGLE)))
+        assertEquals(Quadrant.NorthEast, Quadrant.from(Degrees(NeMidAngle)))
+        assertEquals(Quadrant.SouthEast, Quadrant.from(Degrees(SeMidAngle)))
+        assertEquals(Quadrant.SouthWest, Quadrant.from(Degrees(SwMidAngle)))
+        assertEquals(Quadrant.NorthWest, Quadrant.from(Degrees(NwMidAngle)))
     }
 
     /**
@@ -47,20 +47,20 @@ class CircularLabelPositionProviderTest {
     fun `Quadrant#from normalizes and returns the correct Quadrant for angles greater than 270 degrees`() {
         assertEquals(Quadrant.NorthEast, Quadrant.from(Degrees(275.0)))
 
-        assertEquals(Quadrant.NorthEast, Quadrant.from(Degrees(1 * 360f + NE_MID_ANGLE)))
-        assertEquals(Quadrant.SouthEast, Quadrant.from(Degrees(2 * 360f + SE_MID_ANGLE)))
-        assertEquals(Quadrant.SouthWest, Quadrant.from(Degrees(3 * 360f + SW_MID_ANGLE)))
-        assertEquals(Quadrant.NorthWest, Quadrant.from(Degrees(4 * 360f + NW_MID_ANGLE)))
+        assertEquals(Quadrant.NorthEast, Quadrant.from(Degrees(1 * 360f + NeMidAngle)))
+        assertEquals(Quadrant.SouthEast, Quadrant.from(Degrees(2 * 360f + SeMidAngle)))
+        assertEquals(Quadrant.SouthWest, Quadrant.from(Degrees(3 * 360f + SwMidAngle)))
+        assertEquals(Quadrant.NorthWest, Quadrant.from(Degrees(4 * 360f + NwMidAngle)))
     }
 
     @Test
     fun `Quadrant#from normalizes and returns the correct Quadrant for angles less than -90 degrees`() {
         assertEquals(Quadrant.NorthWest, Quadrant.from(Degrees(-95.0)))
 
-        assertEquals(Quadrant.NorthEast, Quadrant.from(Degrees(1 * -360f + NE_MID_ANGLE)))
-        assertEquals(Quadrant.SouthEast, Quadrant.from(Degrees(2 * -360f + SE_MID_ANGLE)))
-        assertEquals(Quadrant.SouthWest, Quadrant.from(Degrees(3 * -360f + SW_MID_ANGLE)))
-        assertEquals(Quadrant.NorthWest, Quadrant.from(Degrees(4 * -360f + NW_MID_ANGLE)))
+        assertEquals(Quadrant.NorthEast, Quadrant.from(Degrees(1 * -360f + NeMidAngle)))
+        assertEquals(Quadrant.SouthEast, Quadrant.from(Degrees(2 * -360f + SeMidAngle)))
+        assertEquals(Quadrant.SouthWest, Quadrant.from(Degrees(3 * -360f + SwMidAngle)))
+        assertEquals(Quadrant.NorthWest, Quadrant.from(Degrees(4 * -360f + NwMidAngle)))
     }
     //endregion
 }


### PR DESCRIPTION
As the title says, I wanted to be able to configure the starting angle of my pie chart (https://github.com/KoalaPlot/koalaplot-core/issues/79)

Only issue I found is when the angle is set to some small fraction like 179.999, then somewhere the logic will produce too many label placeables and it will crash. Haven't found the origin for that yet

FYI: I also tried to add a configurable `pieMaxAngle` to be able to create half pies, but when creating `makePieSliceData` with this 180 degree angle instead of full circle, the code crashed somewhere else.