### PR TITLE
Add coerceAtLeast to fix  Zoom range limit when range is small

### DIFF
--- a/src/commonMain/kotlin/io/github/koalaplot/core/xygraph/IntLinearAxisModel.kt
+++ b/src/commonMain/kotlin/io/github/koalaplot/core/xygraph/IntLinearAxisModel.kt
@@ -227,7 +227,7 @@ public class IntLinearAxisModel(
 @Composable
 public fun rememberIntLinearAxisModel(
     range: IntRange,
-    zoomRangeLimit: Int = ((range.last - range.first) * ZoomRangeLimitDefault).toInt(),
+    zoomRangeLimit: Int = ((range.last - range.first) * ZoomRangeLimitDefault).coerceAtLeast(1.0).toInt(),
     minimumMajorTickIncrement: Int = ((range.last - range.first) * MinimumMajorTickIncrementDefault).toInt(),
     minimumMajorTickSpacing: Dp = 50.dp,
     minorTickCount: Int = 4,


### PR DESCRIPTION
Naive fix for https://github.com/KoalaPlot/koalaplot-core/issues/81

- Duplicating same logic for calcualting `zoomRangeLimit `as is in [IntLinearAxisModel](https://github.com/KoalaPlot/koalaplot-core/blob/main/src/commonMain/kotlin/io/github/koalaplot/core/xygraph/IntLinearAxisModel.kt#L37)



------
_feel free to close it if not satisfactory_