### PR TITLE
feat(PieChart): mark composable scope as BoxScope for holeContent

### DIFF
--- a/src/commonMain/kotlin/io/github/koalaplot/core/pie/PieChart.kt
+++ b/src/commonMain/kotlin/io/github/koalaplot/core/pie/PieChart.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size

--- a/src/commonMain/kotlin/io/github/koalaplot/core/pie/PieChart.kt
+++ b/src/commonMain/kotlin/io/github/koalaplot/core/pie/PieChart.kt
@@ -199,10 +199,10 @@ public fun PieChart(
         val colors = remember(values.size) { generateHueColorPalette(values.size) }
         DefaultSlice(colors[it])
     },
-    label: @Composable (Int) -> Unit = {},
+    label: @Composable BoxScope.(Int) -> Unit = {},
     labelConnector: @Composable LabelConnectorScope.(Int) -> Unit = { StraightLineConnector() },
     holeSize: Float = 0f,
-    holeContent: @Composable () -> Unit = {},
+    holeContent: @Composable BoxScope.() -> Unit = {},
     minPieDiameter: Dp = 100.dp,
     maxPieDiameter: Dp = 300.dp,
     forceCenteredPie: Boolean = false,
@@ -338,11 +338,11 @@ public fun PieChart(
         val colors = remember(values.size) { generateHueColorPalette(values.size) }
         DefaultSlice(colors[it])
     },
-    label: @Composable (Int) -> Unit = {},
+    label: @Composable BoxScope.(Int) -> Unit = {},
     labelConnector: @Composable LabelConnectorScope.(Int) -> Unit = { StraightLineConnector() },
     labelSpacing: Float = DefaultLabelDiameterScale,
     holeSize: Float = 0f,
-    holeContent: @Composable () -> Unit = {},
+    holeContent: @Composable BoxScope.() -> Unit = {},
     minPieDiameter: Dp = 100.dp,
     maxPieDiameter: Dp = 300.dp,
     forceCenteredPie: Boolean = false,

--- a/src/commonMain/kotlin/io/github/koalaplot/core/pie/PieChart.kt
+++ b/src/commonMain/kotlin/io/github/koalaplot/core/pie/PieChart.kt
@@ -200,7 +200,7 @@ public fun PieChart(
         val colors = remember(values.size) { generateHueColorPalette(values.size) }
         DefaultSlice(colors[it])
     },
-    label: @Composable BoxScope.(Int) -> Unit = {},
+    label: @Composable (Int) -> Unit = {},
     labelConnector: @Composable LabelConnectorScope.(Int) -> Unit = { StraightLineConnector() },
     holeSize: Float = 0f,
     holeContent: @Composable BoxScope.() -> Unit = {},
@@ -339,7 +339,7 @@ public fun PieChart(
         val colors = remember(values.size) { generateHueColorPalette(values.size) }
         DefaultSlice(colors[it])
     },
-    label: @Composable BoxScope.(Int) -> Unit = {},
+    label: @Composable (Int) -> Unit = {},
     labelConnector: @Composable LabelConnectorScope.(Int) -> Unit = { StraightLineConnector() },
     labelSpacing: Float = DefaultLabelDiameterScale,
     holeSize: Float = 0f,


### PR DESCRIPTION
To be able to use the proper modifiers for alignment etc, mark the pie composable lambdas for holeContent with `BoxScope`