### PR TITLE
[issue-95] enhancement: make start animation value configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ hs_err_pid*
 *.hprof
 
 local.properties
+.kotlin

--- a/src/commonMain/kotlin/io/github/koalaplot/core/animation/StartAnimationUseCase.kt
+++ b/src/commonMain/kotlin/io/github/koalaplot/core/animation/StartAnimationUseCase.kt
@@ -46,7 +46,8 @@ public class StartAnimationUseCase(
     }
 
     public enum class ExecutionType {
-        Default, None,
+        Default,
+        None,
     }
 
     private companion object {

--- a/src/commonMain/kotlin/io/github/koalaplot/core/animation/StartAnimationUseCase.kt
+++ b/src/commonMain/kotlin/io/github/koalaplot/core/animation/StartAnimationUseCase.kt
@@ -51,7 +51,7 @@ public class StartAnimationUseCase(
     }
 
     private companion object {
-        private const val START_ANIMATION_VALUE: Float = 0f
-        private const val TARGET_ANIMATION_VALUE: Float = 1f
+        private const val START_ANIMATION_VALUE = 0f
+        private const val TARGET_ANIMATION_VALUE = 1f
     }
 }

--- a/src/commonMain/kotlin/io/github/koalaplot/core/animation/StartAnimationUseCase.kt
+++ b/src/commonMain/kotlin/io/github/koalaplot/core/animation/StartAnimationUseCase.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 
 /**
+ * @param executionType Controls the execution of this animation use case.
  * @param chartAnimationSpec Specifies the animation to use when the chart is first drawn.
  * @param labelAnimationSpec Specifies the animation to use when the labels are drawn. Drawing of the labels begins
  * after the chart animation is complete.

--- a/src/commonMain/kotlin/io/github/koalaplot/core/animation/StartAnimationUseCase.kt
+++ b/src/commonMain/kotlin/io/github/koalaplot/core/animation/StartAnimationUseCase.kt
@@ -1,44 +1,35 @@
 package io.github.koalaplot.core.animation
 
+import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 
 /**
  * @param executionType Controls the execution of this animation use case.
- * @param chartAnimationSpec Specifies the animation to use when the chart is first drawn.
- * @param labelAnimationSpec Specifies the animation to use when the labels are drawn. Drawing of the labels begins
- * after the chart animation is complete.
+ * @param chartAnimationSpecs Specifies all animations to use.
  */
 public class StartAnimationUseCase(
     private val executionType: ExecutionType = ExecutionType.Default,
-    private val chartAnimationSpec: AnimationSpec<Float>,
-    private val labelAnimationSpec: AnimationSpec<Float>,
+    private vararg val chartAnimationSpecs: AnimationSpec<Float>,
 ) {
 
-    public val chartAnimationStartValue: Float
-        get() = when (executionType) {
-            ExecutionType.Default -> START_ANIMATION_VALUE
-            ExecutionType.None -> TARGET_ANIMATION_VALUE
+    public val animatables: List<Animatable<Float, AnimationVector1D>> by lazy {
+        chartAnimationSpecs.map {
+            Animatable(getAnimationStartValue())
         }
-
-    public val labelAnimationStartValue: Float
-        get() = when (executionType) {
-            ExecutionType.Default -> START_ANIMATION_VALUE
-            ExecutionType.None -> TARGET_ANIMATION_VALUE
-        }
+    }
 
     @Composable
-    public operator fun invoke(
-        key: Any,
-        onStartAnimation: suspend (AnimationSpecs) -> Unit,
-    ) {
+    public operator fun invoke(key: Any) {
         when (executionType) {
             ExecutionType.Default -> {
-                executeDefault(
-                    key = key,
-                    onStartAnimation = onStartAnimation,
-                )
+                LaunchedEffect(key1 = key) {
+                    chartAnimationSpecs.forEachIndexed { index, animationSpec ->
+                        animatables[index].animateTo(TARGET_ANIMATION_VALUE, animationSpec)
+                    }
+                }
             }
 
             ExecutionType.None -> {
@@ -47,33 +38,19 @@ public class StartAnimationUseCase(
         }
     }
 
-    @Composable
-    private fun executeDefault(
-        key: Any,
-        onStartAnimation: suspend (AnimationSpecs) -> Unit,
-    ) {
-        LaunchedEffect(key1 = key) {
-            onStartAnimation.invoke(
-                AnimationSpecs(
-                    chartAnimationSpec = chartAnimationSpec,
-                    labelAnimationSpec = labelAnimationSpec,
-                )
-            )
+    private fun getAnimationStartValue(): Float {
+        return when (executionType) {
+            ExecutionType.Default -> START_ANIMATION_VALUE
+            ExecutionType.None -> TARGET_ANIMATION_VALUE
         }
     }
 
-    public data class AnimationSpecs(
-        val chartAnimationSpec: AnimationSpec<Float>,
-        val labelAnimationSpec: AnimationSpec<Float>,
-    )
-
     public enum class ExecutionType {
-        Default,
-        None,
+        Default, None,
     }
 
-    public companion object {
-        public const val START_ANIMATION_VALUE: Float = 0f
-        public const val TARGET_ANIMATION_VALUE: Float = 1f
+    private companion object {
+        private const val START_ANIMATION_VALUE: Float = 0f
+        private const val TARGET_ANIMATION_VALUE: Float = 1f
     }
 }

--- a/src/commonMain/kotlin/io/github/koalaplot/core/animation/StartAnimationUseCase.kt
+++ b/src/commonMain/kotlin/io/github/koalaplot/core/animation/StartAnimationUseCase.kt
@@ -1,0 +1,78 @@
+package io.github.koalaplot.core.animation
+
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+
+/**
+ * @param chartAnimationSpec Specifies the animation to use when the chart is first drawn.
+ * @param labelAnimationSpec Specifies the animation to use when the labels are drawn. Drawing of the labels begins
+ * after the chart animation is complete.
+ */
+public class StartAnimationUseCase(
+    private val executionType: ExecutionType = ExecutionType.Default,
+    private val chartAnimationSpec: AnimationSpec<Float>,
+    private val labelAnimationSpec: AnimationSpec<Float>,
+) {
+
+    public val chartAnimationStartValue: Float
+        get() = when (executionType) {
+            ExecutionType.Default -> START_ANIMATION_VALUE
+            ExecutionType.None -> TARGET_ANIMATION_VALUE
+        }
+
+    public val labelAnimationStartValue: Float
+        get() = when (executionType) {
+            ExecutionType.Default -> START_ANIMATION_VALUE
+            ExecutionType.None -> TARGET_ANIMATION_VALUE
+        }
+
+    @Composable
+    public operator fun invoke(
+        key: Any,
+        onStartAnimation: suspend (AnimationSpecs) -> Unit,
+    ) {
+        when (executionType) {
+            ExecutionType.Default -> {
+                executeDefault(
+                    key = key,
+                    onStartAnimation = onStartAnimation,
+                )
+            }
+
+            ExecutionType.None -> {
+                // no animation start
+            }
+        }
+    }
+
+    @Composable
+    private fun executeDefault(
+        key: Any,
+        onStartAnimation: suspend (AnimationSpecs) -> Unit,
+    ) {
+        LaunchedEffect(key1 = key) {
+            onStartAnimation.invoke(
+                AnimationSpecs(
+                    chartAnimationSpec = chartAnimationSpec,
+                    labelAnimationSpec = labelAnimationSpec,
+                )
+            )
+        }
+    }
+
+    public data class AnimationSpecs(
+        val chartAnimationSpec: AnimationSpec<Float>,
+        val labelAnimationSpec: AnimationSpec<Float>,
+    )
+
+    public enum class ExecutionType {
+        Default,
+        None,
+    }
+
+    public companion object {
+        public const val START_ANIMATION_VALUE: Float = 0f
+        public const val TARGET_ANIMATION_VALUE: Float = 1f
+    }
+}

--- a/src/commonMain/kotlin/io/github/koalaplot/core/pie/PieChart.kt
+++ b/src/commonMain/kotlin/io/github/koalaplot/core/pie/PieChart.kt
@@ -1,6 +1,5 @@
 package io.github.koalaplot.core.pie
 
-import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
@@ -220,8 +219,8 @@ public fun PieChart(
     startAnimationUseCase: StartAnimationUseCase =
         StartAnimationUseCase(
             executionType = StartAnimationUseCase.ExecutionType.Default,
-            chartAnimationSpec = KoalaPlotTheme.animationSpec,
-            labelAnimationSpec = tween(LabelFadeInDuration, 0, LinearOutSlowInEasing)
+            /* chart animation */ KoalaPlotTheme.animationSpec,
+            /* label animation */  tween(LabelFadeInDuration, 0, LinearOutSlowInEasing)
         ),
     pieStartAngle: AngularValue = AngleCCWTop.deg,
     pieExtendAngle: AngularValue = DegreesFullCircle.deg,
@@ -231,16 +230,13 @@ public fun PieChart(
     require(pieExtendAngle.toDegrees().value > 0f && pieExtendAngle.toDegrees().value <= DegreesFullCircle) {
         "pieExtendAngle must be between 0 and 360, exclusive of 0"
     }
+    require(startAnimationUseCase.animatables.size == 2) { "startAnimationUseCase must have 2 animatables" }
 
     val currentValues by rememberUpdatedState(values)
-    val beta = remember(values) { Animatable(startAnimationUseCase.chartAnimationStartValue) }
-    val labelAlpha = remember(values) { Animatable(startAnimationUseCase.labelAnimationStartValue) }
+    val beta = remember(values) { startAnimationUseCase.animatables[0] }
+    val labelAlpha = remember(values) { startAnimationUseCase.animatables[1] }
 
-    startAnimationUseCase(key = values) { animationSpecs ->
-        beta.animateTo(StartAnimationUseCase.TARGET_ANIMATION_VALUE, animationSpec = animationSpecs.chartAnimationSpec)
-        // fade in labels after pie animation is complete
-        labelAlpha.animateTo(StartAnimationUseCase.TARGET_ANIMATION_VALUE, animationSpecs.labelAnimationSpec)
-    }
+    startAnimationUseCase(key = values)
 
     // pieSliceData that gets animated - used for drawing the pie
     val pieSliceData by remember(beta.value) {
@@ -370,8 +366,8 @@ public fun PieChart(
     startAnimationUseCase: StartAnimationUseCase =
         StartAnimationUseCase(
             executionType = StartAnimationUseCase.ExecutionType.Default,
-            chartAnimationSpec = KoalaPlotTheme.animationSpec,
-            labelAnimationSpec = tween(LabelFadeInDuration, 0, LinearOutSlowInEasing)
+            KoalaPlotTheme.animationSpec,
+            tween(LabelFadeInDuration, 0, LinearOutSlowInEasing)
         ),
 ) {
     require(labelSpacing >= 1f) { "labelSpacing must be greater than 1" }

--- a/src/commonMain/kotlin/io/github/koalaplot/core/pie/PieChart.kt
+++ b/src/commonMain/kotlin/io/github/koalaplot/core/pie/PieChart.kt
@@ -293,8 +293,10 @@ public fun PieChart(
     startAnimationUseCase: StartAnimationUseCase =
         StartAnimationUseCase(
             executionType = StartAnimationUseCase.ExecutionType.Default,
-            /* chart animation */ KoalaPlotTheme.animationSpec,
-            /* label animation */  tween(LabelFadeInDuration, 0, LinearOutSlowInEasing)
+            /* chart animation */
+            KoalaPlotTheme.animationSpec,
+            /* label animation */
+            tween(LabelFadeInDuration, 0, LinearOutSlowInEasing)
         ),
     pieStartAngle: AngularValue = AngleCCWTop.deg,
     pieExtendAngle: AngularValue = DegreesFullCircle.deg,
@@ -507,7 +509,9 @@ public fun PieChart(
     startAnimationUseCase: StartAnimationUseCase =
         StartAnimationUseCase(
             executionType = StartAnimationUseCase.ExecutionType.Default,
+            /* chart animation */
             KoalaPlotTheme.animationSpec,
+            /* label animation */
             tween(LabelFadeInDuration, 0, LinearOutSlowInEasing)
         ),
 ) {

--- a/src/commonMain/kotlin/io/github/koalaplot/core/pie/PieChart.kt
+++ b/src/commonMain/kotlin/io/github/koalaplot/core/pie/PieChart.kt
@@ -417,8 +417,75 @@ public fun PieChart(
  * @param maxPieDiameter Maximum diameter allowed for the pie. May be Infinity but not Unspecified.
  * @param forceCenteredPie If true, will force the pie to be centered within its parent, by adjusting (decreasing) the
  * pie size to accommodate label sizes and positions. If false, will maximize the pie diameter.
- * @param startAnimationUseCase Controls the animation.
+ * @param pieAnimationSpec Specifies the animation to use when the pie chart is first drawn.
+ * @param labelAnimationSpec Specifies the animation to use when the labels are drawn. Drawing of the labels begins
  * after the pie animation is complete.
+ */
+@ExperimentalKoalaPlotApi
+@Composable
+public fun PieChart(
+    values: List<Float>,
+    modifier: Modifier = Modifier,
+    slice: @Composable PieSliceScope.(Int) -> Unit = {
+        val colors = remember(values.size) { generateHueColorPalette(values.size) }
+        DefaultSlice(colors[it])
+    },
+    label: @Composable (Int) -> Unit = {},
+    labelConnector: @Composable LabelConnectorScope.(Int) -> Unit = { StraightLineConnector() },
+    labelSpacing: Float = DefaultLabelDiameterScale,
+    holeSize: Float = 0f,
+    holeContent: @Composable BoxScope.(contentPadding: PaddingValues) -> Unit = {},
+    minPieDiameter: Dp = 100.dp,
+    maxPieDiameter: Dp = 300.dp,
+    forceCenteredPie: Boolean = false,
+    pieAnimationSpec: AnimationSpec<Float> = KoalaPlotTheme.animationSpec,
+    labelAnimationSpec: AnimationSpec<Float> = tween(LabelFadeInDuration, 0, LinearOutSlowInEasing),
+) {
+    PieChart(
+        values = values,
+        modifier = modifier,
+        slice = slice,
+        label = label,
+        labelConnector = labelConnector,
+        labelSpacing = labelSpacing,
+        holeSize = holeSize,
+        holeContent = holeContent,
+        minPieDiameter = minPieDiameter,
+        maxPieDiameter = maxPieDiameter,
+        forceCenteredPie = forceCenteredPie,
+        startAnimationUseCase =
+        StartAnimationUseCase(
+            executionType = StartAnimationUseCase.ExecutionType.Default,
+            pieAnimationSpec,
+            labelAnimationSpec,
+        ),
+    )
+}
+
+/**
+ * Creates a Pie Chart or, optionally, a Donut Chart if holeSize is nonZero, with optional
+ * hole content to place at the center of the donut hole. Pie slices are drawn starting at
+ * -90 degrees (top center), progressing clockwise around the pie. Each slice occupies a fraction
+ * of the overall pie according to its data value relative to the sum of all values. Places labels around the pie
+ * at a minimum distance set by [labelSpacing].
+ *
+ * @param values The data values for each pie slice
+ * @param modifier Compose Modifiers to be applied to the overall PieChart
+ * @param slice Composable for a pie slice.
+ * @param label Composable for a pie slice label placed around the perimeter of the pie
+ * @param labelConnector Composable for label connectors connecting the pie slice to the label
+ * @param labelSpacing A value greater than 1 specifying the distance from the center of
+ * the pie at which to place the labels relative to the overall diameter of the pie, where a value
+ * of 1 is at the outer edge of the pie. Values between 1.05 and 1.4 tend to work well depending
+ * on the size of the labels and overall pie diameter.
+ * @param holeSize A relative size for an inner hole of the pie, creating a donut chart, with a
+ * value between 0 and 1.
+ * @param holeContent Optional content that may be placed in the space of the donut hole.
+ * @param minPieDiameter Minimum diameter allowed for the pie.
+ * @param maxPieDiameter Maximum diameter allowed for the pie. May be Infinity but not Unspecified.
+ * @param forceCenteredPie If true, will force the pie to be centered within its parent, by adjusting (decreasing) the
+ * pie size to accommodate label sizes and positions. If false, will maximize the pie diameter.
+ * @param startAnimationUseCase Controls the animation.
  */
 @ExperimentalKoalaPlotApi
 @Composable

--- a/src/commonMain/kotlin/io/github/koalaplot/core/pie/PieChart.kt
+++ b/src/commonMain/kotlin/io/github/koalaplot/core/pie/PieChart.kt
@@ -222,6 +222,8 @@ public fun PieChart(
     forceCenteredPie: Boolean = false,
     pieAnimationSpec: AnimationSpec<Float> = KoalaPlotTheme.animationSpec,
     labelAnimationSpec: AnimationSpec<Float> = tween(LabelFadeInDuration, 0, LinearOutSlowInEasing),
+    labelAnimationSpecStartValue: Float = 0f,
+    pieAnimationSpecStartValue: Float = 0f,
     pieStartAngle: AngularValue = AngleCCWTop.deg,
     pieExtendAngle: AngularValue = DegreesFullCircle.deg,
 ) {
@@ -232,8 +234,8 @@ public fun PieChart(
     }
 
     val currentValues by rememberUpdatedState(values)
-    val beta = remember(values) { Animatable(0f) }
-    val labelAlpha = remember(values) { Animatable(0f) }
+    val beta = remember(values) { Animatable(labelAnimationSpecStartValue) }
+    val labelAlpha = remember(values) { Animatable(pieAnimationSpecStartValue) }
 
     LaunchedEffect(values) {
         beta.animateTo(1f, animationSpec = pieAnimationSpec)
@@ -369,6 +371,8 @@ public fun PieChart(
     forceCenteredPie: Boolean = false,
     pieAnimationSpec: AnimationSpec<Float> = KoalaPlotTheme.animationSpec,
     labelAnimationSpec: AnimationSpec<Float> = tween(LabelFadeInDuration, 0, LinearOutSlowInEasing),
+    labelAnimationSpecStartValue: Float = 0f,
+    pieAnimationSpecStartValue: Float = 0f,
 ) {
     require(labelSpacing >= 1f) { "labelSpacing must be greater than 1" }
     PieChart(
@@ -384,7 +388,9 @@ public fun PieChart(
         maxPieDiameter,
         forceCenteredPie,
         pieAnimationSpec,
-        labelAnimationSpec
+        labelAnimationSpec,
+        labelAnimationSpecStartValue = labelAnimationSpecStartValue,
+        pieAnimationSpecStartValue = pieAnimationSpecStartValue,
     )
 }
 

--- a/src/commonMain/kotlin/io/github/koalaplot/core/pie/PieChart.kt
+++ b/src/commonMain/kotlin/io/github/koalaplot/core/pie/PieChart.kt
@@ -222,8 +222,8 @@ public fun PieChart(
     forceCenteredPie: Boolean = false,
     pieAnimationSpec: AnimationSpec<Float> = KoalaPlotTheme.animationSpec,
     labelAnimationSpec: AnimationSpec<Float> = tween(LabelFadeInDuration, 0, LinearOutSlowInEasing),
-    labelAnimationSpecStartValue: Float = 0f,
     pieAnimationSpecStartValue: Float = 0f,
+    labelAnimationSpecStartValue: Float = 0f,
     pieStartAngle: AngularValue = AngleCCWTop.deg,
     pieExtendAngle: AngularValue = DegreesFullCircle.deg,
 ) {
@@ -234,8 +234,8 @@ public fun PieChart(
     }
 
     val currentValues by rememberUpdatedState(values)
-    val beta = remember(values) { Animatable(labelAnimationSpecStartValue) }
-    val labelAlpha = remember(values) { Animatable(pieAnimationSpecStartValue) }
+    val beta = remember(values) { Animatable(pieAnimationSpecStartValue) }
+    val labelAlpha = remember(values) { Animatable(labelAnimationSpecStartValue) }
 
     LaunchedEffect(values) {
         beta.animateTo(1f, animationSpec = pieAnimationSpec)
@@ -371,8 +371,8 @@ public fun PieChart(
     forceCenteredPie: Boolean = false,
     pieAnimationSpec: AnimationSpec<Float> = KoalaPlotTheme.animationSpec,
     labelAnimationSpec: AnimationSpec<Float> = tween(LabelFadeInDuration, 0, LinearOutSlowInEasing),
-    labelAnimationSpecStartValue: Float = 0f,
     pieAnimationSpecStartValue: Float = 0f,
+    labelAnimationSpecStartValue: Float = 0f,
 ) {
     require(labelSpacing >= 1f) { "labelSpacing must be greater than 1" }
     PieChart(
@@ -389,8 +389,8 @@ public fun PieChart(
         forceCenteredPie,
         pieAnimationSpec,
         labelAnimationSpec,
-        labelAnimationSpecStartValue = labelAnimationSpecStartValue,
         pieAnimationSpecStartValue = pieAnimationSpecStartValue,
+        labelAnimationSpecStartValue = labelAnimationSpecStartValue,
     )
 }
 

--- a/src/commonMain/kotlin/io/github/koalaplot/core/pie/PieChart.kt
+++ b/src/commonMain/kotlin/io/github/koalaplot/core/pie/PieChart.kt
@@ -1,5 +1,6 @@
 package io.github.koalaplot.core.pie
 
+import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
@@ -171,6 +172,79 @@ internal data class LabelConnectorScopeImpl(
 private const val InitOuterRadius = 0.95f
 
 private const val LabelFadeInDuration = 1000
+
+/**
+ * Creates a Pie Chart or, optionally, a Donut Chart if holeSize is nonZero, with optional
+ * hole content to place at the center of the donut hole. Pie slices are drawn starting at
+ * -90 degrees (top center), progressing clockwise around the pie. Each slice occupies a fraction
+ * of the overall pie according to its data value relative to the sum of all values.
+ *
+ * @param values The data values for each pie slice
+ * @param labelPositionProvider A provider of label offsets that can be used to implement different label
+ * placement strategies. See the [PieChart] override for a version that uses labels placed around the circumference
+ * of the pie.
+ * @param modifier Compose Modifiers to be applied to the overall PieChart
+ * @param slice Composable for a pie slice.
+ * @param label Composable for a pie slice label placed around the perimeter of the pie
+ * @param labelConnector Composable for label connectors connecting the pie slice to the label
+ * @param holeSize A relative size for an inner hole of the pie, creating a donut chart, with a
+ * value between 0 and 1.
+ * @param holeContent Optional content that may be placed in the space of the donut hole. To safely draw the content
+ * within the hole without intersecting with the chart, apply the passed `contentPadding` to your content composable.
+ * @param minPieDiameter Minimum diameter allowed for the pie.
+ * @param maxPieDiameter Maximum diameter allowed for the pie. May be Infinity but not Unspecified.
+ * @param forceCenteredPie If true, will force the pie to be centered within its parent, by adjusting (decreasing) the
+ * pie size to accommodate label sizes and positions. If false, will maximize the pie diameter.
+ * @param pieAnimationSpec Specifies the animation to use when the pie chart is first drawn.
+ * @param labelAnimationSpec Specifies the animation to use when the labels are drawn. Drawing of the labels begins
+ * after the pie animation is complete.
+ * @param pieStartAngle Sets an angle for the pie data to start at. Defaults to the top of the pie.
+ * @param pieExtendAngle Sets a max angle for the pie to extend to, with a value between 1 and 360.
+ * Defaults to [DegreesFullCircle].
+ */
+@ExperimentalKoalaPlotApi
+@Composable
+public fun PieChart(
+    values: List<Float>,
+    labelPositionProvider: LabelPositionProvider,
+    modifier: Modifier = Modifier,
+    slice: @Composable PieSliceScope.(Int) -> Unit = {
+        val colors = remember(values.size) { generateHueColorPalette(values.size) }
+        DefaultSlice(colors[it])
+    },
+    label: @Composable (Int) -> Unit = {},
+    labelConnector: @Composable LabelConnectorScope.(Int) -> Unit = { StraightLineConnector() },
+    holeSize: Float = 0f,
+    holeContent: @Composable BoxScope.(contentPadding: PaddingValues) -> Unit = {},
+    minPieDiameter: Dp = 100.dp,
+    maxPieDiameter: Dp = 300.dp,
+    forceCenteredPie: Boolean = false,
+    pieAnimationSpec: AnimationSpec<Float> = KoalaPlotTheme.animationSpec,
+    labelAnimationSpec: AnimationSpec<Float> = tween(LabelFadeInDuration, 0, LinearOutSlowInEasing),
+    pieStartAngle: AngularValue = AngleCCWTop.deg,
+    pieExtendAngle: AngularValue = DegreesFullCircle.deg,
+) {
+    PieChart(
+        values = values,
+        labelPositionProvider = labelPositionProvider,
+        modifier = modifier,
+        slice = slice,
+        label = label,
+        labelConnector = labelConnector,
+        holeSize = holeSize,
+        holeContent = holeContent,
+        minPieDiameter = minPieDiameter,
+        maxPieDiameter = maxPieDiameter,
+        forceCenteredPie = forceCenteredPie,
+        pieStartAngle = pieStartAngle,
+        pieExtendAngle = pieExtendAngle,
+        startAnimationUseCase = StartAnimationUseCase(
+            executionType = StartAnimationUseCase.ExecutionType.Default,
+            pieAnimationSpec,
+            labelAnimationSpec,
+        )
+    )
+}
 
 /**
  * Creates a Pie Chart or, optionally, a Donut Chart if holeSize is nonZero, with optional


### PR DESCRIPTION
Make start animation value configurable.

i've added these two parameter to the PieChart-composable:

```
labelAnimationSpecStartValue: Float = 0f,
pieAnimationSpecStartValue: Float = 0f,
```

below

`labelAnimationSpec: AnimationSpec<Float> = KoalaPlotTheme.animationSpec,`

And apply them here:

```
val beta = remember(values) { Animatable(labelAnimationSpecStartValue) }
val labelAlpha = remember(values) { Animatable(pieAnimationSpecStartValue) }
```

You can now overwrite the default values from PieChart
`labelAnimationSpecStartValue` and `pieAnimationSpecStartValue` to 1f  to disable the animation for googles sceenshot-testing.

Issue was: https://github.com/KoalaPlot/koalaplot-core/issues/95