### PR TITLE
Transfer the logic of enabling/disabling pan and zoom to the gesture handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Support for StartAnimationUseCase in bar-chart (GroupedVerticalBarPlot)
+- Ability to disable the consumption of gesture events
+
+### Changed
+
+- Move the logic of enabling/disabling pan and zoom to the gesture handler
+- A separate object has been created for the gesture configuration GestureConfig
+- Removing the gesture logic "pastTouchSlop", in practice it turned out to be inconsistent when capturing panning
+  from the parent container
+
+### Fixed
+
+- Discrete panning in X and Y axes (#104)
 
 ## [0.8.0]
 

--- a/src/androidMain/kotlin/io/github/koalaplot/core/util/ModifierExtensions.android.kt
+++ b/src/androidMain/kotlin/io/github/koalaplot/core/util/ModifierExtensions.android.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.IntSize
 import io.github.koalaplot.core.gestures.DefaultTransformGesturesHandler
+import io.github.koalaplot.core.gestures.GestureConfig
 import io.github.koalaplot.core.gestures.TransformGesturesHandlerWithLockZoomRatio
 
 /**
@@ -14,21 +15,18 @@ import io.github.koalaplot.core.gestures.TransformGesturesHandlerWithLockZoomRat
 internal actual fun Modifier.onGestureInput(
     key1: Any?,
     key2: Any?,
-    panLock: Boolean,
-    zoomLock: Boolean,
-    lockZoomRatio: Boolean,
-    onZoomChange: (size: IntSize, centroid: Offset, zoomX: Float, zoomY: Float) -> Unit,
-    onPanChange: (size: IntSize, pan: Offset) -> Unit,
-): Modifier = this then Modifier.pointerInput(key1, key2, panLock, zoomLock, lockZoomRatio) {
-    val gesturesHandler = if (lockZoomRatio) {
-        TransformGesturesHandlerWithLockZoomRatio()
-    } else {
+    gestureConfig: GestureConfig,
+    onZoomChange: (size: IntSize, centroid: Offset, zoom: ZoomFactor) -> Unit,
+    onPanChange: (size: IntSize, pan: Offset) -> Boolean,
+): Modifier = this then Modifier.pointerInput(key1, key2, gestureConfig) {
+    val gesturesHandler = if (gestureConfig.independentZoomEnabled) {
         DefaultTransformGesturesHandler()
+    } else {
+        TransformGesturesHandlerWithLockZoomRatio()
     }
     gesturesHandler.detectTransformGestures(
         scope = this,
-        panLock = panLock,
-        zoomLock = zoomLock,
+        gestureConfig = gestureConfig,
         onZoomChange = onZoomChange,
         onPanChange = onPanChange
     )

--- a/src/commonMain/kotlin/io/github/koalaplot/core/gestures/GestureConfig.kt
+++ b/src/commonMain/kotlin/io/github/koalaplot/core/gestures/GestureConfig.kt
@@ -1,0 +1,113 @@
+package io.github.koalaplot.core.gestures
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
+
+/**
+ * Configuration for gesture handling, including settings for panning and zooming and their use
+ *
+ * @property panXEnabled Whether the pan is enabled for the X-axis
+ * @property panYEnabled Whether the pan is enabled for the Y-axis
+ * @property panXConsumptionEnabled Whether the pan on the X-axis should be consumed.
+ * Has no effect for `js` and `wasmJs`
+ * @property panYConsumptionEnabled Whether the pan on the Y-axis should be consumed.
+ * Has no effect for `js` and `wasmJs`
+ * @property zoomXEnabled Whether the zoom is enabled for the X-axis
+ * @property zoomYEnabled Whether the zoom is enabled for the Y-axis
+ * @property independentZoomEnabled Whether independent zoom (zooming on X and Y axes separately) is allowed
+ */
+@Immutable
+public data class GestureConfig(
+
+    /**
+     * Whether the pan gesture is enabled for the X-axis
+     * If `true`, pan gestures along the X-axis will be processed
+     * If `false`, no pan gestures will be handled for the X-axis
+     */
+    val panXEnabled: Boolean = false,
+
+    /**
+     * Whether the pan gesture is enabled for the Y-axis
+     * If `true`, pan gestures along the Y-axis will be processed
+     * If `false`, no pan gestures will be handled for the Y-axis
+     */
+    val panYEnabled: Boolean = false,
+
+    /**
+     * Whether the pan gesture on the X-axis should be consumed. Has no effect for `js` and `wasmJs`
+     * If `true`, the pan gesture will be consumed and will not propagate further
+     * If `false`, the pan gesture will not be consumed and may propagate. However, the gesture will still be
+     * processed but `PointerInputChange#consume` will not be called, allowing parent containers to process
+     * the gesture if needed
+     */
+    val panXConsumptionEnabled: Boolean = true,
+
+    /**
+     * Whether the pan gesture on the Y-axis should be consumed. Has no effect for `js` and `wasmJs`
+     * If `true`, the pan gesture will be consumed and will not propagate further
+     * If `false`, the pan gesture will not be consumed and may propagate. However, the gesture will still be
+     * processed but `PointerInputChange#consume` will not be called, allowing parent containers to process
+     * the gesture if needed
+     */
+    val panYConsumptionEnabled: Boolean = true,
+
+    /**
+     * Whether the zoom gesture is enabled for the X-axis
+     * If `true`, zoom gestures along the X-axis will be processed
+     * If `false`, no zoom gestures will be handled for the X-axis
+     */
+    val zoomXEnabled: Boolean = false,
+
+    /**
+     * Whether the zoom gesture is enabled for the Y-axis
+     * If `true`, zoom gestures along the Y-axis will be processed
+     * If `false`, no zoom gestures will be handled for the Y-axis
+     */
+    val zoomYEnabled: Boolean = false,
+
+    /**
+     * Whether independent zoom (zooming on X and Y axes separately) is allowed
+     *
+     * If `true`, the zoom can be either only on the X axis, or only on the Y axis,
+     * or independently on the X and Y axes at the same time (the behavior depends on the target platform),
+     * False if the total zoom factor must be used.
+     *
+     * If `false`, zooming will be locked to a single ratio (X and Y zoom together)
+     *
+     * Behavior for Android and iOS:
+     * True does not mean getting independent zoom coefficients simultaneously for each axis,
+     * if the zoom was initiated:
+     * - horizontally - the zoom coefficient will change only for the X axis,
+     * - vertically - the zoom coefficient will change only for the Y axis.
+     *
+     * Behavior for Desktop platforms:
+     * True means getting independent zoom coefficients simultaneously or separately for each axis,
+     * if the zoom was initiated:
+     * - horizontally - the zoom coefficient will change only for the X axis,
+     * - vertically - the zoom coefficient will change only for the Y axis,
+     * - diagonally - the zoom coefficient will change along the axes X and Y at the same time
+     *
+     * Behavior for JS and wasmJS:
+     * True means getting independent zoom coefficients simultaneously or separately for each axis,
+     * if the zoom was initiated:
+     * - horizontally - the zoom coefficient will change only for the X axis,
+     * - vertically - the zoom coefficient will change only for the Y axis,
+     * - diagonally - the zoom coefficient will change along the axes X and Y at the same time.
+     *
+     * JS and wasmJS have slight differences in response behavior (for example, zoom coefficients for the same gesture
+     * will be interpreted with a difference of several tenths or hundredths), and zoom handling with the mouse wheel
+     * scroll while pressing Ctrl/Cmd is not supported (a problem with browser scaling)
+     */
+    val independentZoomEnabled: Boolean = false,
+) {
+    @Stable
+    val gesturesEnabled: Boolean
+        get() = panXEnabled || panYEnabled || zoomXEnabled || zoomYEnabled
+
+    @Stable
+    val panEnabled: Boolean
+        get() = panXEnabled || panYEnabled
+
+    @Stable
+    val zoomEnabled: Boolean = zoomXEnabled || zoomYEnabled
+}

--- a/src/commonMain/kotlin/io/github/koalaplot/core/gestures/Gestures.kt
+++ b/src/commonMain/kotlin/io/github/koalaplot/core/gestures/Gestures.kt
@@ -7,6 +7,8 @@ import androidx.compose.ui.util.fastForEach
 import io.github.koalaplot.core.util.ZoomFactor
 import kotlin.math.abs
 
+internal const val DefaultPanValue = 0f
+
 internal fun PointerEvent.consumeChangedPositions() {
     changes.fastForEach { change ->
         if (change.positionChanged()) change.consume()
@@ -19,13 +21,6 @@ internal fun Offset.getDistanceY(): Float = abs(y)
 
 /**
  * Returns the largest zoom value of the two axes
- * @param zoom The current zoom value on the X or Y axes
- * @param size The width of the area for the [zoom] axis
- */
-internal fun calculateZoomMotion(zoom: Float, size: Float): Float = abs(ZoomFactor.NeutralPoint - zoom) * size
-
-/**
- * Returns the largest zoom value of the two axes
  * @param zoomX The current zoom value on the X axis
  * @param zoomY The current zoom value on the Y axis
  */
@@ -34,3 +29,13 @@ internal fun getMaxZoomDeviation(zoomX: Float, zoomY: Float): Float {
     val deviationY = abs(zoomY - ZoomFactor.NeutralPoint)
     return if (deviationX > deviationY) zoomX else zoomY
 }
+
+internal fun Offset.applyPanLocks(panXEnabled: Boolean, panYEnabled: Boolean): Offset = this.copy(
+    x = if (panXEnabled) this.x else DefaultPanValue,
+    y = if (panYEnabled) this.y else DefaultPanValue,
+)
+
+internal fun ZoomFactor.applyZoomLocks(zoomXEnabled: Boolean, zoomYEnabled: Boolean): ZoomFactor = this.copy(
+    x = if (zoomXEnabled) this.x else ZoomFactor.NeutralPoint,
+    y = if (zoomYEnabled) this.y else ZoomFactor.NeutralPoint,
+)

--- a/src/commonMain/kotlin/io/github/koalaplot/core/gestures/TransformGesturesHandler.kt
+++ b/src/commonMain/kotlin/io/github/koalaplot/core/gestures/TransformGesturesHandler.kt
@@ -3,6 +3,7 @@ package io.github.koalaplot.core.gestures
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerInputScope
 import androidx.compose.ui.unit.IntSize
+import io.github.koalaplot.core.util.ZoomFactor
 
 /**
  * Interface for handling touch-based transformation gestures, such as zoom and pan
@@ -11,9 +12,8 @@ internal interface TransformGesturesHandler {
 
     suspend fun detectTransformGestures(
         scope: PointerInputScope,
-        panLock: Boolean,
-        zoomLock: Boolean,
-        onZoomChange: (size: IntSize, centroid: Offset, zoomX: Float, zoomY: Float) -> Unit,
-        onPanChange: (size: IntSize, pan: Offset) -> Unit,
+        gestureConfig: GestureConfig,
+        onZoomChange: (size: IntSize, centroid: Offset, zoom: ZoomFactor) -> Unit,
+        onPanChange: (size: IntSize, pan: Offset) -> Boolean,
     )
 }

--- a/src/commonMain/kotlin/io/github/koalaplot/core/util/ModifierExtensions.kt
+++ b/src/commonMain/kotlin/io/github/koalaplot/core/util/ModifierExtensions.kt
@@ -3,6 +3,7 @@ package io.github.koalaplot.core.util
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.IntSize
+import io.github.koalaplot.core.gestures.GestureConfig
 
 /**
  * Create a modifier for gesture processing
@@ -25,19 +26,14 @@ import androidx.compose.ui.unit.IntSize
  *
  * @param key1 see [androidx.compose.ui.input.pointer.pointerInput]
  * @param key2 see [androidx.compose.ui.input.pointer.pointerInput]
- * @param panLock If `true`, it blocks pan handling
- * @param zoomLock If `true`, it blocks zoom handling
- * @param lockZoomRatio If `true`, the split zoom will be blocked and the zoom will be calculated simultaneously
- * for the X and Y axes
+ * @param gestureConfig Configuration for gesture handling. See [GestureConfig]
  * @param onZoomChange Called every time the zoom changes
  * @param onPanChange Called every time the pan changes
  */
 internal expect fun Modifier.onGestureInput(
     key1: Any?,
     key2: Any?,
-    panLock: Boolean = false,
-    zoomLock: Boolean = false,
-    lockZoomRatio: Boolean = false,
-    onZoomChange: (size: IntSize, centroid: Offset, zoomX: Float, zoomY: Float) -> Unit,
-    onPanChange: (size: IntSize, pan: Offset) -> Unit,
+    gestureConfig: GestureConfig,
+    onZoomChange: (size: IntSize, centroid: Offset, zoom: ZoomFactor) -> Unit,
+    onPanChange: (size: IntSize, pan: Offset) -> Boolean,
 ): Modifier

--- a/src/commonMain/kotlin/io/github/koalaplot/core/xygraph/AxisModel.kt
+++ b/src/commonMain/kotlin/io/github/koalaplot/core/xygraph/AxisModel.kt
@@ -61,5 +61,7 @@ public interface AxisModel<T> {
      * the axis by 10% of its current range, increasing the values. Negative values will pan by
      * decreasing the minimum and maximum axis range.
      */
-    public fun pan(amount: Float) {}
+    public fun pan(amount: Float): Boolean {
+        return false
+    }
 }

--- a/src/commonMain/kotlin/io/github/koalaplot/core/xygraph/DoubleLinearAxisModel.kt
+++ b/src/commonMain/kotlin/io/github/koalaplot/core/xygraph/DoubleLinearAxisModel.kt
@@ -29,8 +29,6 @@ import kotlin.math.sign
  * @param minimumMajorTickSpacing Specifies the minimum physical spacing for major ticks, in
  * Dp units. Must be greater than 0.
  * @param minorTickCount The number of minor ticks per major tick interval.
- * @param allowZooming If the axis should allow zooming
- * @param allowPanning If the axis should allow panning.
  */
 public class DoubleLinearAxisModel(
     public override val range: ClosedFloatingPointRange<Double>,
@@ -40,8 +38,6 @@ public class DoubleLinearAxisModel(
         (range.endInclusive - range.start) * MinimumMajorTickIncrementDefault,
     override val minimumMajorTickSpacing: Dp = 50.dp,
     private val minorTickCount: Int = 4,
-    private val allowZooming: Boolean = true,
-    private val allowPanning: Boolean = true,
     private val inverted: Boolean = false,
 ) : ContinuousLinearAxisModel<Double> {
     init {
@@ -186,7 +182,7 @@ public class DoubleLinearAxisModel(
     }
 
     override fun zoom(zoomFactor: Float, pivot: Float) {
-        if (!allowZooming || zoomFactor == 1f) return
+        if (zoomFactor == 1f) return
 
         require(zoomFactor > 0) { "Zoom amount must be greater than 0" }
         require(pivot in 0.0..1.0) { "Zoom pivot must be between 0 and 1: $pivot" }
@@ -207,9 +203,7 @@ public class DoubleLinearAxisModel(
         }
     }
 
-    override fun pan(amount: Float) {
-        if (!allowPanning) return
-
+    override fun pan(amount: Float): Boolean {
         // convert pan amount to axis range space
         val panAxisScale = (currentRange.value.endInclusive - currentRange.value.start) * amount
 
@@ -220,7 +214,10 @@ public class DoubleLinearAxisModel(
         val newLow = (currentRange.value.start + panLimited)
         val newHi = (currentRange.value.endInclusive + panLimited)
 
+        val result = currentRange.value != newLow..newHi
+
         currentRange.value = newLow..newHi
+        return result
     }
 
     override fun setViewRange(newRange: ClosedRange<Double>) {
@@ -258,9 +255,7 @@ public class DoubleLinearAxisModel(
         if (minViewExtent != other.minViewExtent) return false
         if (minimumMajorTickIncrement != other.minimumMajorTickIncrement) return false
         if (minimumMajorTickSpacing != other.minimumMajorTickSpacing) return false
-        if (minorTickCount != other.minorTickCount) return false
-        if (allowZooming != other.allowZooming) return false
-        return allowPanning == other.allowPanning
+        return minorTickCount == other.minorTickCount
     }
 
     override fun hashCode(): Int {
@@ -269,8 +264,6 @@ public class DoubleLinearAxisModel(
         result = 31 * result + minimumMajorTickIncrement.hashCode()
         result = 31 * result + minimumMajorTickSpacing.hashCode()
         result = 31 * result + minorTickCount
-        result = 31 * result + allowZooming.hashCode()
-        result = 31 * result + allowPanning.hashCode()
         return result
     }
 }
@@ -286,16 +279,12 @@ public fun rememberDoubleLinearAxisModel(
     minimumMajorTickIncrement: Double = (range.endInclusive - range.start) * MinimumMajorTickIncrementDefault,
     minimumMajorTickSpacing: Dp = 50.dp,
     minorTickCount: Int = 4,
-    allowZooming: Boolean = true,
-    allowPanning: Boolean = true,
 ): DoubleLinearAxisModel = remember(
     range,
     minViewExtent,
     minimumMajorTickIncrement,
     minimumMajorTickSpacing,
     minorTickCount,
-    allowZooming,
-    allowPanning
 ) {
     DoubleLinearAxisModel(
         range,
@@ -304,8 +293,6 @@ public fun rememberDoubleLinearAxisModel(
         minimumMajorTickIncrement,
         minimumMajorTickSpacing,
         minorTickCount,
-        allowZooming,
-        allowPanning
     )
 }
 

--- a/src/commonMain/kotlin/io/github/koalaplot/core/xygraph/FloatLinearAxisModel.kt
+++ b/src/commonMain/kotlin/io/github/koalaplot/core/xygraph/FloatLinearAxisModel.kt
@@ -30,8 +30,6 @@ import kotlin.math.sign
  * @param minimumMajorTickSpacing Specifies the minimum physical spacing for major ticks, in
  * Dp units. Must be greater than 0.
  * @param minorTickCount The number of minor ticks per major tick interval.
- * @param allowZooming If the axis should allow zooming
- * @param allowPanning If the axis should allow panning.
  * @param inverted If the axis coordinates should be inverted so smaller values are at the top/right.
  */
 public class FloatLinearAxisModel(
@@ -42,8 +40,6 @@ public class FloatLinearAxisModel(
         (range.endInclusive - range.start) * MinimumMajorTickIncrementDefault,
     override val minimumMajorTickSpacing: Dp = 50.dp,
     private val minorTickCount: Int = 4,
-    private val allowZooming: Boolean = true,
-    private val allowPanning: Boolean = true,
     private val inverted: Boolean = false,
 ) : ContinuousLinearAxisModel<Float> {
     init {
@@ -182,7 +178,7 @@ public class FloatLinearAxisModel(
     }
 
     override fun zoom(zoomFactor: Float, pivot: Float) {
-        if (!allowZooming || zoomFactor == 1f) return
+        if (zoomFactor == 1f) return
 
         require(zoomFactor > 0) { "Zoom amount must be greater than 0" }
         require(pivot in 0.0..1.0) { "Zoom pivot must be between 0 and 1: $pivot" }
@@ -203,9 +199,7 @@ public class FloatLinearAxisModel(
         }
     }
 
-    override fun pan(amount: Float) {
-        if (!allowPanning) return
-
+    override fun pan(amount: Float): Boolean {
         // convert pan amount to axis range space
         val panAxisScale = (currentRange.value.endInclusive - currentRange.value.start) * amount
 
@@ -216,7 +210,10 @@ public class FloatLinearAxisModel(
         val newLow = (currentRange.value.start + panLimited)
         val newHi = (currentRange.value.endInclusive + panLimited)
 
+        val result = currentRange.value != newLow..newHi
+
         currentRange.value = newLow..newHi
+        return result
     }
 
     override fun setViewRange(newRange: ClosedRange<Float>) {
@@ -254,9 +251,7 @@ public class FloatLinearAxisModel(
         if (minViewExtent != other.minViewExtent) return false
         if (minimumMajorTickIncrement != other.minimumMajorTickIncrement) return false
         if (minimumMajorTickSpacing != other.minimumMajorTickSpacing) return false
-        if (minorTickCount != other.minorTickCount) return false
-        if (allowZooming != other.allowZooming) return false
-        return allowPanning == other.allowPanning
+        return minorTickCount == other.minorTickCount
     }
 
     override fun hashCode(): Int {
@@ -265,8 +260,6 @@ public class FloatLinearAxisModel(
         result = 31 * result + minimumMajorTickIncrement.hashCode()
         result = 31 * result + minimumMajorTickSpacing.hashCode()
         result = 31 * result + minorTickCount
-        result = 31 * result + allowZooming.hashCode()
-        result = 31 * result + allowPanning.hashCode()
         return result
     }
 }
@@ -282,16 +275,12 @@ public fun rememberFloatLinearAxisModel(
     minimumMajorTickIncrement: Float = (range.endInclusive - range.start) * MinimumMajorTickIncrementDefault,
     minimumMajorTickSpacing: Dp = 50.dp,
     minorTickCount: Int = 4,
-    allowZooming: Boolean = true,
-    allowPanning: Boolean = true,
 ): FloatLinearAxisModel = remember(
     range,
     minViewExtent,
     minimumMajorTickIncrement,
     minimumMajorTickSpacing,
     minorTickCount,
-    allowZooming,
-    allowPanning
 ) {
     FloatLinearAxisModel(
         range,
@@ -300,8 +289,6 @@ public fun rememberFloatLinearAxisModel(
         minimumMajorTickIncrement,
         minimumMajorTickSpacing,
         minorTickCount,
-        allowZooming,
-        allowPanning
     )
 }
 

--- a/src/commonMain/kotlin/io/github/koalaplot/core/xygraph/IntLinearAxisModel.kt
+++ b/src/commonMain/kotlin/io/github/koalaplot/core/xygraph/IntLinearAxisModel.kt
@@ -30,8 +30,6 @@ import kotlin.math.roundToInt
  * @param minimumMajorTickSpacing Specifies the minimum physical spacing for major ticks, in
  * Dp units. Must be greater than 0.
  * @param minorTickCount The number of minor ticks per major tick interval.
- * @param allowZooming If the axis should allow zooming
- * @param allowPanning If the axis should allow panning.
  * @param inverted If the axis coordinates should be inverted so smaller values are at the top/right.
  */
 public class IntLinearAxisModel(
@@ -43,8 +41,6 @@ public class IntLinearAxisModel(
         ).toInt(),
     override val minimumMajorTickSpacing: Dp = 50.dp,
     private val minorTickCount: Int = 4,
-    private val allowZooming: Boolean = true,
-    private val allowPanning: Boolean = true,
     private val inverted: Boolean = false,
 ) : DiscreteLinearAxisModel<Int> {
     init {
@@ -187,7 +183,7 @@ public class IntLinearAxisModel(
     }
 
     override fun zoom(zoomFactor: Float, pivot: Float) {
-        if (!allowZooming || zoomFactor == 1f) return
+        if (zoomFactor == 1f) return
 
         require(zoomFactor > 0) { "Zoom amount must be greater than 0" }
         require(pivot in 0.0..1.0) { "Zoom pivot must be between 0 and 1: $pivot" }
@@ -208,9 +204,7 @@ public class IntLinearAxisModel(
         }
     }
 
-    override fun pan(amount: Float) {
-        if (!allowPanning) return
-
+    override fun pan(amount: Float): Boolean {
         // convert pan amount to axis range space
         val panAxisScale = ((currentRange.value.endInclusive - currentRange.value.start) * amount)
 
@@ -221,7 +215,10 @@ public class IntLinearAxisModel(
         val newLow = (currentRange.value.start + panLimited)
         val newHi = (currentRange.value.endInclusive + panLimited)
 
+        val result = currentRange.value != newLow..newHi
+
         currentRange.value = newLow..newHi
+        return result
     }
 
     override fun setViewRange(newRange: ClosedRange<Double>) {
@@ -259,9 +256,7 @@ public class IntLinearAxisModel(
         if (minViewExtent != other.minViewExtent) return false
         if (minimumMajorTickIncrement != other.minimumMajorTickIncrement) return false
         if (minimumMajorTickSpacing != other.minimumMajorTickSpacing) return false
-        if (minorTickCount != other.minorTickCount) return false
-        if (allowZooming != other.allowZooming) return false
-        return allowPanning == other.allowPanning
+        return minorTickCount == other.minorTickCount
     }
 
     override fun hashCode(): Int {
@@ -270,8 +265,6 @@ public class IntLinearAxisModel(
         result = 31 * result + minimumMajorTickIncrement.hashCode()
         result = 31 * result + minimumMajorTickSpacing.hashCode()
         result = 31 * result + minorTickCount
-        result = 31 * result + allowZooming.hashCode()
-        result = 31 * result + allowPanning.hashCode()
         return result
     }
 }
@@ -287,16 +280,12 @@ public fun rememberIntLinearAxisModel(
     minimumMajorTickIncrement: Int = ((range.last - range.first) * MinimumMajorTickIncrementDefault).toInt(),
     minimumMajorTickSpacing: Dp = 50.dp,
     minorTickCount: Int = 4,
-    allowZooming: Boolean = true,
-    allowPanning: Boolean = true,
 ): IntLinearAxisModel = remember(
     range,
     minViewExtent,
     minimumMajorTickIncrement,
     minimumMajorTickSpacing,
     minorTickCount,
-    allowZooming,
-    allowPanning
 ) {
     IntLinearAxisModel(
         range,
@@ -305,8 +294,6 @@ public fun rememberIntLinearAxisModel(
         minimumMajorTickIncrement,
         minimumMajorTickSpacing,
         minorTickCount,
-        allowZooming,
-        allowPanning
     )
 }
 

--- a/src/commonMain/kotlin/io/github/koalaplot/core/xygraph/XYGraph.kt
+++ b/src/commonMain/kotlin/io/github/koalaplot/core/xygraph/XYGraph.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import io.github.koalaplot.core.gestures.GestureConfig
 import io.github.koalaplot.core.style.KoalaPlotTheme
 import io.github.koalaplot.core.style.LineStyle
 import io.github.koalaplot.core.util.Deg2Rad
@@ -60,37 +61,7 @@ import kotlin.math.sin
  * @param yAxisStyle Style for the y-axis
  * @param yAxisLabels Composable to display labels for specific y-axis values
  * @param yAxisTitle Title for the y-axis
- * @param panEnabled True if the plot can be panned, false to disable. Enabling panning may
- * interfere with scrolling a parent container if the drag point is on the plot.
- * @param zoomEnabled True if the plot can be zoomed, false to disable. Enabling zooming may
- * interfere with scrolling a parent container if the drag point is on the plot.
- * @param allowIndependentZoom True if the zoom can be either only on the X axis, or only on the Y axis,
- * or independently on the X and Y axes at the same time (the behavior depends on the target platform),
- * False if the total zoom factor must be used.
- *
- * Behavior for Android and iOS:
- * True does not mean getting independent zoom coefficients simultaneously for each axis,
- * if the zoom was initiated:
- * - horizontally - the zoom coefficient will change only for the X axis,
- * - vertically - the zoom coefficient will change only for the Y axis.
- *
- * Behavior for Desktop platforms: (EXPERIMENTAL!)
- * True means getting independent zoom coefficients simultaneously or separately for each axis,
- * if the zoom was initiated:
- * - horizontally - the zoom coefficient will change only for the X axis,
- * - vertically - the zoom coefficient will change only for the Y axis,
- * - diagonally - the zoom coefficient will change along the axes X and Y at the same time
- *
- * Behavior for JS and wasmJS: (EXPERIMENTAL!)
- * True means getting independent zoom coefficients simultaneously or separately for each axis,
- * if the zoom was initiated:
- * - horizontally - the zoom coefficient will change only for the X axis,
- * - vertically - the zoom coefficient will change only for the Y axis,
- * - diagonally - the zoom coefficient will change along the axes X and Y at the same time.
- *
- * JS and wasmJS have slight differences in response behavior (for example, zoom coefficients for the same gesture
- * will be interpreted with a difference of several tenths or hundredths), and zoom handling with the mouse wheel
- * scroll while pressing Ctrl/Cmd is not supported (a problem with browser scaling)
+ * @param gestureConfig Configuration for gesture handling. See [GestureConfig]
  * @param content The content to be displayed, which should include one plot for each series to be
  * plotted on this XYGraph.
  */
@@ -110,9 +81,7 @@ public fun <X, Y> XYGraph(
     horizontalMinorGridLineStyle: LineStyle? = KoalaPlotTheme.axis.minorGridlineStyle,
     verticalMajorGridLineStyle: LineStyle? = KoalaPlotTheme.axis.majorGridlineStyle,
     verticalMinorGridLineStyle: LineStyle? = KoalaPlotTheme.axis.minorGridlineStyle,
-    panEnabled: Boolean = false,
-    zoomEnabled: Boolean = false,
-    allowIndependentZoom: Boolean = false,
+    gestureConfig: GestureConfig = GestureConfig(),
     content: @Composable XYGraphScope<X, Y>.() -> Unit
 ) {
     HoverableElementArea(modifier = modifier) {
@@ -147,22 +116,25 @@ public fun <X, Y> XYGraph(
             val yAxisMeasurable = subcompose("yaxis") { Axis(yAxis) }[0]
 
             val chartMeasurable = subcompose("chart") {
-                val panZoomModifier = if (panEnabled || zoomEnabled) {
+                val panZoomModifier = if (gestureConfig.gesturesEnabled) {
                     Modifier.onGestureInput(
                         key1 = xAxisModel,
                         key2 = yAxisModel,
-                        panLock = !panEnabled,
-                        zoomLock = !zoomEnabled,
-                        lockZoomRatio = !allowIndependentZoom,
-                        onZoomChange = { size, centroid, zoomX, zoomY ->
+                        gestureConfig = gestureConfig,
+                        onZoomChange = { size, centroid, zoom ->
                             val normalizedCentroid = centroid.normalizeCentroid(size)
-                            zoomAxis(xAxisModel, size.width, normalizedCentroid.x, zoomX)
-                            zoomAxis(yAxisModel, size.height, normalizedCentroid.y, zoomY)
+                            zoomAxis(xAxisModel, size.width, normalizedCentroid.x, zoom.x)
+                            zoomAxis(yAxisModel, size.height, normalizedCentroid.y, zoom.y)
                         },
                         onPanChange = { size, pan ->
                             val normalizedPan = pan.normalizePan()
-                            panAxis(xAxisModel, size.width, normalizedPan.x)
-                            panAxis(yAxisModel, size.height, normalizedPan.y)
+                            val xPanChanged = panAxis(xAxisModel, size.width, normalizedPan.x)
+                            val yPanChanged = panAxis(yAxisModel, size.height, normalizedPan.y)
+
+                            val allowXPanConsumption = xPanChanged && gestureConfig.panXConsumptionEnabled
+                            val allowYPanConsumption = yPanChanged && gestureConfig.panYConsumptionEnabled
+
+                            return@onGestureInput allowXPanConsumption || allowYPanConsumption
                         }
                     )
                 } else {
@@ -230,8 +202,8 @@ private fun <T> panAxis(
     axis: AxisModel<T>,
     length: Int,
     pan: Float
-) {
-    axis.pan(pan / length.toFloat())
+): Boolean {
+    return axis.pan(pan / length.toFloat())
 }
 
 /**
@@ -664,15 +636,7 @@ private fun DrawScope.drawGridLine(gridLineStyle: LineStyle?, start: Offset, end
  * @param yAxisStyle Style for the y-axis
  * @param yAxisLabels String factory of y-axis label Strings
  * @param yAxisTitle Title for the y-axis
- * @param panEnabled True if the plot can be panned, false to disable. Enabling panning may
- * interfere with scrolling a parent container if the drag point is on the plot.
- * @param zoomEnabled True if the plot can be zoomed, false to disable. Enabling zooming may
- * interfere with scrolling a parent container if the drag point is on the plot.
- * @param allowIndependentZoom `true` if the zoom can be either X-axis only or Y-axis only,
- * `false` if the total zoom factor must be used.
- * `true` does not mean that independent zoom coefficients are obtained simultaneously for each axis,
- * if the zoom was initiated horizontally - the zoom coefficient will change only for the X axis,
- * if the zoom was initiated vertically - the zoom coefficient will change only for the Y axis.
+ * @param gestureConfig Configuration for gesture handling. See [GestureConfig]
  * @param content The content to be displayed within this graph, which should include one plot for each
  * data series to be plotted.
  */
@@ -692,9 +656,7 @@ public fun <X, Y> XYGraph(
     horizontalMinorGridLineStyle: LineStyle? = KoalaPlotTheme.axis.minorGridlineStyle,
     verticalMajorGridLineStyle: LineStyle? = KoalaPlotTheme.axis.majorGridlineStyle,
     verticalMinorGridLineStyle: LineStyle? = KoalaPlotTheme.axis.minorGridlineStyle,
-    panEnabled: Boolean = false,
-    zoomEnabled: Boolean = false,
-    allowIndependentZoom: Boolean = false,
+    gestureConfig: GestureConfig = GestureConfig(),
     content: @Composable XYGraphScope<X, Y>.() -> Unit
 ) {
     XYGraph(
@@ -747,9 +709,7 @@ public fun <X, Y> XYGraph(
         horizontalMinorGridLineStyle,
         verticalMajorGridLineStyle,
         verticalMinorGridLineStyle,
-        panEnabled,
-        zoomEnabled,
-        allowIndependentZoom,
+        gestureConfig,
         content
     )
 }

--- a/src/desktopTest/kotlin/io/github/koalaplot/core/gestures/GesturesTest.kt
+++ b/src/desktopTest/kotlin/io/github/koalaplot/core/gestures/GesturesTest.kt
@@ -1,0 +1,162 @@
+package io.github.koalaplot.core.gestures
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.junit4.createComposeRule
+import io.github.koalaplot.core.util.ExperimentalKoalaPlotApi
+import io.github.koalaplot.core.util.ZoomFactor
+import io.github.koalaplot.core.xygraph.FloatLinearAxisModel
+import io.github.koalaplot.core.xygraph.XYGraph
+import org.junit.Rule
+import org.junit.Test
+import kotlin.math.abs
+import kotlin.test.assertEquals
+
+class GesturesTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun testApplyPanLocks() {
+        val testPanXValue = 110f
+        val testPanYValue = 150f
+        val testPan = Offset(testPanXValue, testPanYValue)
+
+        val actual1 = testPan.applyPanLocks(panXEnabled = false, panYEnabled = false)
+        val actual2 = testPan.applyPanLocks(panXEnabled = false, panYEnabled = true)
+        val actual3 = testPan.applyPanLocks(panXEnabled = true, panYEnabled = false)
+        val actual4 = testPan.applyPanLocks(panXEnabled = true, panYEnabled = true)
+
+        assertEquals(actual1.x, DefaultPanValue)
+        assertEquals(actual1.y, DefaultPanValue)
+
+        assertEquals(actual2.x, DefaultPanValue)
+        assertEquals(actual2.y, testPanYValue)
+
+        assertEquals(actual3.x, testPanXValue)
+        assertEquals(actual3.y, DefaultPanValue)
+
+        assertEquals(actual4.x, testPanXValue)
+        assertEquals(actual4.y, testPanYValue)
+    }
+
+    @Test
+    fun testApplyZoomLocks() {
+        val testZoomXValue = 3.4f
+        val testZoomYValue = 1.7f
+        val testZoomFactor = ZoomFactor(testZoomXValue, testZoomYValue)
+
+        val actual1 = testZoomFactor.applyZoomLocks(zoomXEnabled = false, zoomYEnabled = false)
+        val actual2 = testZoomFactor.applyZoomLocks(zoomXEnabled = false, zoomYEnabled = true)
+        val actual3 = testZoomFactor.applyZoomLocks(zoomXEnabled = true, zoomYEnabled = false)
+        val actual4 = testZoomFactor.applyZoomLocks(zoomXEnabled = true, zoomYEnabled = true)
+
+        assertEquals(actual1, ZoomFactor.Neutral)
+
+        assertEquals(actual2.x, ZoomFactor.NeutralPoint)
+        assertEquals(actual2.y, testZoomYValue)
+        assertEquals(actual2.y, testZoomFactor.y)
+
+        assertEquals(actual3.x, testZoomXValue)
+        assertEquals(actual3.x, testZoomFactor.x)
+        assertEquals(actual3.y, ZoomFactor.NeutralPoint)
+
+        assertEquals(actual4.x, testZoomXValue)
+        assertEquals(actual4.x, testZoomFactor.x)
+        assertEquals(actual4.y, testZoomYValue)
+        assertEquals(actual4.y, testZoomFactor.y)
+    }
+
+    @Test
+    fun testGetMaxZoomDeviation() {
+        val testCases = listOf(
+            ZoomFactor(-1.0f, 2.0f),
+            ZoomFactor(2.0f, -1.0f),
+            ZoomFactor(0.5f, 1.5f),
+            ZoomFactor(3.0f, 1.0f),
+            ZoomFactor(-0.5f, 2.5f),
+            ZoomFactor(0.0f, 0.0f),
+            ZoomFactor(1.0f, 1.0f),
+            ZoomFactor(-2.0f, 4.0f),
+            ZoomFactor(2.5f, -0.5f),
+            ZoomFactor(-1.5f, -3.5f)
+        )
+
+        for (testCase in testCases) {
+            val expected = if (abs(testCase.x - ZoomFactor.NeutralPoint) > abs(testCase.y - ZoomFactor.NeutralPoint)) {
+                testCase.x
+            } else {
+                testCase.y
+            }
+
+            val actual = getMaxZoomDeviation(testCase.x, testCase.y)
+            assertEquals(expected, actual, "Failed for $testCase")
+        }
+    }
+
+    @OptIn(ExperimentalKoalaPlotApi::class)
+    @Test
+    fun testGestureConfig() {
+        val gestureConfig1 = GestureConfig(
+            panXEnabled = true,
+            panYEnabled = true,
+            panXConsumptionEnabled = true,
+            panYConsumptionEnabled = true,
+            zoomXEnabled = true,
+            zoomYEnabled = true,
+            independentZoomEnabled = true
+        )
+
+        val gestureConfig2 = GestureConfig(
+            panXEnabled = false,
+            panYEnabled = false,
+            panXConsumptionEnabled = false,
+            panYConsumptionEnabled = false,
+            zoomXEnabled = false,
+            zoomYEnabled = false,
+            independentZoomEnabled = false
+        )
+
+        val gestureConfig3 = GestureConfig(
+            panXEnabled = true,
+            panYEnabled = false,
+            panXConsumptionEnabled = true,
+            panYConsumptionEnabled = false,
+            zoomXEnabled = true,
+            zoomYEnabled = false,
+            independentZoomEnabled = true
+        )
+
+        val gestureConfig4 = GestureConfig(
+            panXEnabled = false,
+            panYEnabled = true,
+            panXConsumptionEnabled = false,
+            panYConsumptionEnabled = true,
+            zoomXEnabled = false,
+            zoomYEnabled = true,
+            independentZoomEnabled = false
+        )
+
+        composeTestRule.setContent {
+            @Composable
+            fun testXYGraphWithGestureConfig(gestureConfig: GestureConfig) {
+                XYGraph(
+                    xAxisModel = FloatLinearAxisModel(
+                        -100f..100f,
+                    ),
+                    yAxisModel = FloatLinearAxisModel(
+                        range = -100f..100f
+                    ),
+                    gestureConfig = gestureConfig
+                ) {
+                }
+            }
+
+            testXYGraphWithGestureConfig(gestureConfig = gestureConfig1)
+            testXYGraphWithGestureConfig(gestureConfig = gestureConfig2)
+            testXYGraphWithGestureConfig(gestureConfig = gestureConfig3)
+            testXYGraphWithGestureConfig(gestureConfig = gestureConfig4)
+        }
+    }
+}

--- a/src/iosMain/kotlin/io/github/koalaplot/core/util/ModifierExtensions.ios.kt
+++ b/src/iosMain/kotlin/io/github/koalaplot/core/util/ModifierExtensions.ios.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.IntSize
 import io.github.koalaplot.core.gestures.DefaultTransformGesturesHandler
+import io.github.koalaplot.core.gestures.GestureConfig
 import io.github.koalaplot.core.gestures.TransformGesturesHandlerWithLockZoomRatio
 
 /**
@@ -14,21 +15,18 @@ import io.github.koalaplot.core.gestures.TransformGesturesHandlerWithLockZoomRat
 internal actual fun Modifier.onGestureInput(
     key1: Any?,
     key2: Any?,
-    panLock: Boolean,
-    zoomLock: Boolean,
-    lockZoomRatio: Boolean,
-    onZoomChange: (size: IntSize, centroid: Offset, zoomX: Float, zoomY: Float) -> Unit,
-    onPanChange: (size: IntSize, pan: Offset) -> Unit,
-): Modifier = this then Modifier.pointerInput(key1, key2, panLock, zoomLock, lockZoomRatio) {
-    val gesturesHandler = if (lockZoomRatio) {
-        TransformGesturesHandlerWithLockZoomRatio()
-    } else {
+    gestureConfig: GestureConfig,
+    onZoomChange: (size: IntSize, centroid: Offset, zoom: ZoomFactor) -> Unit,
+    onPanChange: (size: IntSize, pan: Offset) -> Boolean,
+): Modifier = this then Modifier.pointerInput(key1, key2, gestureConfig) {
+    val gesturesHandler = if (gestureConfig.independentZoomEnabled) {
         DefaultTransformGesturesHandler()
+    } else {
+        TransformGesturesHandlerWithLockZoomRatio()
     }
     gesturesHandler.detectTransformGestures(
         scope = this,
-        panLock = panLock,
-        zoomLock = zoomLock,
+        gestureConfig = gestureConfig,
         onZoomChange = onZoomChange,
         onPanChange = onPanChange
     )


### PR DESCRIPTION
As part of these changes:
- Move the logic of enabling/disabling pan and zoom to the gesture handler
- Add the ability to disable the consumption of gesture events (one of the possible solutions to the problem for #104)
- The chart will consume gestures only if necessary
- Removing the gesture logic "pastTouchSlop", in practice it turned out to be inconsistent when capturing panning
  from the parent container