### PR TITLE
fix: update XYGraphPointerEventScope size not updated after resize

### DIFF
--- a/src/commonMain/kotlin/io/github/koalaplot/core/xygraph/XYGraph.kt
+++ b/src/commonMain/kotlin/io/github/koalaplot/core/xygraph/XYGraph.kt
@@ -343,6 +343,7 @@ private fun <X, Y> Modifier.onPointerMove(
     awaitPointerEventScope {
         while (true) {
             val event = awaitPointerEvent()
+            xyGraphPointerEventScope.size = this.size
             onPointerEvent?.invoke(xyGraphPointerEventScope, event)
         }
     }
@@ -366,7 +367,7 @@ public interface XYGraphPointerEventScope<X, Y> {
 private class XYGraphPointerEventScopeImpl<X, Y>(
     val xAxisModel: AxisModel<X>,
     val yAxisModel: AxisModel<Y>,
-    val size: IntSize,
+    var size: IntSize,
 ) : XYGraphPointerEventScope<X, Y> {
     override fun scale(position: Offset): Point<X, Y> = DefaultPoint(
         xAxisModel.offsetToValue((position.x / size.width).coerceIn(0f, 1f)),


### PR DESCRIPTION
## Problem

`XYGraphPointerEventScopeImpl` is constructed once inside `pointerInput`
capturing the composable's initial `size`. Because `pointerInput` only
restarts when its key parameters change - **not when the layout size
changes** - the scope retains a stale size after any resize (window
resize, orientation change, split-screen, etc.).

This causes pointer coordinates to be translated incorrectly into
data-space X/Y values after the composable is resized.

## Fix

On each pointer event, `xyGraphPointerEventScope.size` is updated with
`AwaitPointerEventScope.size`, which always reflects the current live
layout dimensions:

```kotlin
awaitPointerEventScope {
    while (true) {
        val event = awaitPointerEvent()
        xyGraphPointerEventScope.size = this.size // keep it fresh
        onPointerEvent?.invoke(xyGraphPointerEventScope, event)
    }
}
```

This avoids recreating the scope object on every event while still
keeping the size accurate.

## Testing

Verified by resizing the composable after initial render and confirming
pointer coordinates remain correctly translated to data-space values.