### PR TITLE
Fix pie collapsing when measured with tight constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Pie and donut charts collapsing to their minimum diameter, and being placed outside of their own
+  bounds, when measured with tight constraints such as `Modifier.fillMaxSize()` or `Modifier.size()`.
+
 ## [0.12.0]
 
 ### Changed

--- a/src/commonMain/kotlin/io/github/koalaplot/core/pie/PieMeasurePolicy.kt
+++ b/src/commonMain/kotlin/io/github/koalaplot/core/pie/PieMeasurePolicy.kt
@@ -128,10 +128,16 @@ internal class PieMeasurePolicy(
         minPieDiameterPx: Float,
         maxPieDiameterPx: Float,
     ): Pair<Float, List<Placeable>> {
-        val labelConstraint = constraints.copy(
-            maxWidth = ((constraints.maxWidth - minPieDiameterPx) / 2)
-                .toInt()
-                .coerceAtLeast(constraints.minWidth),
+        // The incoming minimums size the chart as a whole, so they must not be forwarded to the labels:
+        // under tight constraints they would inflate every label to the full size of the chart, leaving no
+        // room for the pie and collapsing it to its minimum diameter.
+        val labelConstraint = Constraints(
+            maxWidth = if (constraints.hasBoundedWidth) {
+                ((constraints.maxWidth - minPieDiameterPx) / 2).toInt().coerceAtLeast(0)
+            } else {
+                Constraints.Infinity
+            },
+            maxHeight = constraints.maxHeight,
         )
 
         val labelPlaceables = labels.map {

--- a/src/desktopTest/kotlin/io/github/koalaplot/core/pie/PieChartTest.kt
+++ b/src/desktopTest/kotlin/io/github/koalaplot/core/pie/PieChartTest.kt
@@ -1,7 +1,14 @@
 package io.github.koalaplot.core.pie
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
 import io.github.koalaplot.core.util.ExperimentalKoalaPlotApi
 import org.junit.Rule
 import org.junit.Test
@@ -80,5 +87,47 @@ class PieChartTest {
         @Suppress("MagicNumber")
         pieData.add(4f)
         composeTestRule.waitForIdle()
+    }
+
+    /**
+     * Test that a pie measured with tight constraints still fills the space it was given. Labels must not
+     * be measured with the chart's own minimum constraints, which would size each of them to the whole
+     * chart and leave no room for the pie.
+     */
+    @OptIn(ExperimentalKoalaPlotApi::class)
+    @Test
+    fun tightConstraintsTest() {
+        val chartSize = 400.dp
+        val minPieDiameter = 100.dp
+        val holeSize = 0.5f
+
+        composeTestRule.setContent {
+            Box(modifier = Modifier.size(chartSize)) {
+                PieChart(
+                    values = listOf(1f, 1f, 1f, 1f),
+                    modifier = Modifier.fillMaxSize(),
+                    holeSize = holeSize,
+                    minPieDiameter = minPieDiameter,
+                    label = { Box(modifier = Modifier.size(20.dp)) },
+                    holeContent = { Box(modifier = Modifier.fillMaxSize().testTag(HoleTag)) },
+                )
+            }
+        }
+        composeTestRule.waitForIdle()
+
+        val collapsedHoleSize = with(composeTestRule.density) { (minPieDiameter * holeSize).roundToPx() }
+        val hole = composeTestRule.onNodeWithTag(HoleTag).fetchSemanticsNode()
+
+        assert(hole.size.width > collapsedHoleSize) {
+            "pie collapsed to its minimum diameter: hole is ${hole.size.width}px, expected wider than " +
+                "$collapsedHoleSize px"
+        }
+        assert(!hole.boundsInRoot.isEmpty) {
+            "pie was placed outside of the chart's bounds: hole bounds are ${hole.boundsInRoot}"
+        }
+    }
+
+    private companion object {
+        const val HoleTag = "hole"
     }
 }


### PR DESCRIPTION
## Summary

Since 0.12.0 a pie or donut chart measured with tight constraints — `Modifier.fillMaxSize()`,
`Modifier.size(...)`, or any parent that propagates its minimums — collapses to `minPieDiameter` and is
then placed outside of its own bounds, so nothing is drawn and no slice receives pointer input. Both
`PieChart` overloads and the new `PieChart { item(...) }` builder are affected, since they share
`PieMeasurePolicy.measure`.

This is a regression against 0.11.2. In 0.11.2 the chart was wrapped in `HoverableElementArea`, whose
`Box` absorbed the incoming minimum constraints before the `SubcomposeLayout` ever saw them. 0.12.0
removed that wrapper and applies the caller's `modifier` directly to the `SubcomposeLayout`, which
exposed a latent bug in how label constraints are derived.

## Reproducing

```kotlin
Box(modifier = Modifier.size(400.dp)) {
    PieChart(
        values = listOf(1f, 1f, 1f, 1f),
        modifier = Modifier.fillMaxSize(),
        holeSize = 0.62f,
        label = { Text("L") },
        holeContent = { Box(modifier = Modifier.fillMaxSize().testTag("hole")) },
    )
}
```

Measured on desktop at density 1 (400 px available, default `minPieDiameter = 100.dp`):

| | 0.11.2 | 0.12.0 |
|---|---|---|
| hole size | 186 × 186 px | 62 × 62 px |
| hole bounds in root | `Rect(106, 106, 292, 292)` | `Rect.Zero` |
| label placeable size | — | 400 × 400 px |

`62 px = 0.62 × 100 px`, i.e. the pie is drawn at exactly `minPieDiameter`. The label subcompositions
come out 400 × 400 — the full size of the chart — even when the label content is empty. Passing loose
constraints instead (`Modifier.fillMaxSize().wrapContentSize()`) restores the 0.11.2 result on 0.12.0,
which isolates the incoming minimums as the trigger.

## Cause

`PieMeasurePolicy.measure` derives the label constraints with `constraints.copy(maxWidth = ...)`. Only
the maximum width is replaced, so `minWidth` and `minHeight` are inherited from the chart's own
constraints. Those minimums describe how large the *chart* must be, not how large a *label* may be, so
under tight constraints every label is forced to the full chart size.

That, in turn, defeats the diameter search: `checkDiameter` asks whether the pie plus its labels still
fit inside `constraints`, which is never true once a single label is as large as the whole chart. The
binary search bottoms out and `findMaxDiameter` returns `minAllowedPieDiameter`. The oversized label
positions then push the layout translation far enough that the pie and the hole land outside the
`clipToBounds` region.

The existing `.coerceAtLeast(constraints.minWidth)` in that expression is a symptom of the same issue:
it exists to keep `minWidth <= maxWidth` valid, a conflict that only arises because `minWidth` is
carried over in the first place.

## Fix

Build the label constraints explicitly with relaxed minimums, and keep an unbounded width unbounded
rather than computing a maximum from `Constraints.Infinity`:

```kotlin
val labelConstraint = Constraints(
    maxWidth = if (constraints.hasBoundedWidth) {
        ((constraints.maxWidth - minPieDiameterPx) / 2).toInt().coerceAtLeast(0)
    } else {
        Constraints.Infinity
    },
    maxHeight = constraints.maxHeight,
)
```

With this change the tight-constraint case measures identically to the loose one, matching 0.11.2
behaviour. Charts measured with loose constraints are unaffected: their minimums were already zero.

## Tests

Adds `PieChartTest.tightConstraintsTest`, which asserts that a `PieChart` filling a 400.dp box is
larger than the collapsed minimum and is placed within its own bounds. The test fails on `main` and
passes with the fix; the rest of `./gradlew check` (detekt, ktlint, all tests) is green.

## Possibly related

#155 reports a `StackOverflowError` from `maximizeUnguarded` for a pie under a tight 100.dp box. That
is a separate defect in the search itself and is not addressed here, but the degenerate search
described above comes from the same code path and may be what drives it into recursion.
